### PR TITLE
Make build.{branch}.properties Optional

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -8,8 +8,20 @@
 		<taskdef resource="net/sf/antcontrib/antlib.xml" />
 		<property environment="env" />
 		<echo>Branch: ${env.CIRCLE_BRANCH}</echo>
-		<property file="build.${env.CIRCLE_BRANCH}.properties" />
-		<echo>${build.cmd}</echo>
+		
+		<if>
+		        <available file="build.${env.CIRCLE_BRANCH}.properties"/>
+		        <then>
+				<property file="build.${env.CIRCLE_BRANCH}.properties" />
+			</then>
+			<else>
+				<property file="build.properties" />
+				<var name="sf.username" value="$${env.${env.CIRCLE_BRANCH}_USERNAME}"/>
+				<var name="sf.password" value="$${env.${env.CIRCLE_BRANCH}_PASSWD}"/>
+			</else>
+		</if>
+		<echo>Build Cmd: ${build.cmd}</echo>
+		<echo>SF User: ${sf.username}</echo>
 		<antcall target="${build.cmd}" />
 	</target>
 	

--- a/build/build.xml
+++ b/build/build.xml
@@ -16,12 +16,23 @@
 			</then>
 			<else>
 				<property file="build.properties" />
-				<var name="sf.username" value="$${env.${env.CIRCLE_BRANCH}_USERNAME}"/>
-				<var name="sf.password" value="$${env.${env.CIRCLE_BRANCH}_PASSWD}"/>
+				
+				<!-- remove "." and "-" from the branch name.
+				Env.Properties cannot have these chars -->
+				<propertyregex property="branch_clean"
+			              input="${env.CIRCLE_BRANCH}"
+			              regexp="[\.\-]"
+			              replace="_"
+			              defaultValue="${env.CIRCLE_BRANCH}"
+			              global="true"
+			              casesensitive="false" />
+			        <!-- echo>Branch Clean: ${branch_clean}</echo -->
+				<var name="sf.username" value="$${env.${branch_clean}_USERNAME}"/>
+				<var name="sf.password" value="$${env.${branch_clean}_PASSWD}"/>
 			</else>
 		</if>
-		<echo>Build Cmd: ${build.cmd}</echo>
 		<echo>SF User: ${sf.username}</echo>
+		<echo>Build Cmd: ${build.cmd}</echo>
 		<antcall target="${build.cmd}" />
 	</target>
 	


### PR DESCRIPTION
This update makes build.{branch}.properties an optional file. This makes it easier to spin-up a new branch/org without needing to create a branch-specific build properties file but still preserves branch-specific username/password environment variables by dynamically building them. However, the branch can still specify a branch-specific properties file.

For now, this change requires that the branch name match the environment variables. Hyphens ("-") and dots (".") are not supported for this, but I'm sure this could be modified to regex that stuff out.

@triestelaporte @mpond76 @dshahin 